### PR TITLE
Lossless compression

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -4,3 +4,5 @@ scanner:
 
 flake8:  
     max-line-length: 89
+
+no_blank_comment: False

--- a/requirements/conda-minimal.txt
+++ b/requirements/conda-minimal.txt
@@ -2,5 +2,5 @@ nose
 msprime
 tskit
 zarr
-kastore
-mock
+daiquiri
+humanize

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -9,3 +9,5 @@ sphinx-issues
 tskit
 zarr
 msprime
+daiquiri
+humanize

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=[
         "numpy",
         "daiquiri",
+        "humanize",
         "tskit",
         "numcodecs",
         "zarr",

--- a/tszip/__init__.py
+++ b/tszip/__init__.py
@@ -29,3 +29,4 @@ except ImportError:
 
 from .compression import compress  # NOQA
 from .compression import decompress  # NOQA
+from .compression import print_summary  # NOQA

--- a/tszip/cli.py
+++ b/tszip/cli.py
@@ -39,7 +39,7 @@ def setup_logging(args):
         log_level = "INFO"
     if args.verbosity > 1:
         log_level = "DEBUG"
-    daiquiri.setup(level=log_level)
+    daiquiri.setup(log_level)
 
 
 def tszip_cli_parser():
@@ -54,8 +54,14 @@ def tszip_cli_parser():
     parser.add_argument(
         "file", help="The file to operate on")
     parser.add_argument(
+        "--variants-only", action='store_true',
+        help="Lossy compression; throws information not needed to represent variants")
+    parser.add_argument(
         "-d", "--decompress", action='store_true',
         help="Decompress")
+    parser.add_argument(
+        "-l", "--list", action='store_true',
+        help="List contents of the file")
     return parser
 
 
@@ -63,7 +69,7 @@ def run_compress(args):
     logger.info("Compressing {}".format(args.file))
     ts = tskit.load(args.file)
     outfile = args.file + ".zarr"
-    tszip.compress(ts, outfile)
+    tszip.compress(ts, outfile, variants_only=args.variants_only)
     # TODO various gzip-like semantics with file
 
 
@@ -77,11 +83,17 @@ def run_decompress(args):
     ts.dump(outfile)
 
 
+def run_list(args):
+    tszip.print_summary(args.file)
+
+
 def tszip_main(arg_list=None):
     parser = tszip_cli_parser()
     args = parser.parse_args(arg_list)
     setup_logging(args)
     if args.decompress:
         run_decompress(args)
+    elif args.list:
+        run_list(args)
     else:
         run_compress(args)


### PR DESCRIPTION
This adds fully lossless compression and also the option to throw away information that's not relevant to storing variants with the ``variants_only`` parameter. The only difference with the variants_only parameter is that we (1) run simplify with ``reduce_to_site_topology`` turned on; and (2) quantise the node times.

There's still a lot of polishing to be done, but I think this is a good first pass for the functionality.