### PR TITLE
Compress top-level metadata

### DIFF
--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -118,7 +118,10 @@ class RoundTripMixin(object):
         self.assertGreater(ts.num_sites, 2)
         self.assertGreater(ts.num_trees, 2)
         tables = ts.dump_tables()
-        top_level_schema = {'codec': 'json', 'properties': {'my_int': {'type': 'integer'}}}
+        top_level_schema = {
+            'codec': 'json',
+            'properties': {'my_int': {'type': 'integer'}}
+        }
         tables.metadata_schema = tskit.MetadataSchema(top_level_schema)
         tables.metadata = {"my_int": 1234}
         self.verify(tables.tree_sequence())

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -113,6 +113,16 @@ class RoundTripMixin(object):
         self.assertGreater(ts.num_trees, 2)
         self.verify(ts)
 
+    def test_small_msprime_top_level_metadata(self):
+        ts = msprime.simulate(10, recombination_rate=2, mutation_rate=2, random_seed=2)
+        self.assertGreater(ts.num_sites, 2)
+        self.assertGreater(ts.num_trees, 2)
+        tables = ts.dump_tables()
+        top_level_schema = {'codec': 'json', 'properties': {'my_int': {'type': 'integer'}}}
+        tables.metadata_schema = tskit.MetadataSchema(top_level_schema)
+        tables.metadata = {"my_int": 1234}
+        self.verify(tables.tree_sequence())
+
     def test_small_msprime_individuals_metadata(self):
         ts = msprime.simulate(10, recombination_rate=1, mutation_rate=2, random_seed=2)
         self.assertGreater(ts.num_sites, 2)

--- a/tszip/compression.py
+++ b/tszip/compression.py
@@ -172,6 +172,9 @@ def compress_zarr(ts, root, variants_only=False):
         root.attrs["format_version"] = FORMAT_VERSION
         root.attrs["sequence_length"] = tables.sequence_length
         root.attrs["provenance"] = provenance_dict
+        if tables.metadata_schema.schema is not None:
+            root.attrs["metadata_schema"] = tables.metadata_schema.schema
+            root.attrs["metadata"] = tables.metadata
 
     columns = [
         Column("coordinates", coordinates),
@@ -280,6 +283,10 @@ def load_zarr(path):
 def decompress_zarr(root):
     tables = tskit.TableCollection(root.attrs["sequence_length"])
     coordinates = root["coordinates"][:]
+    if "metadata_schema" in root.attrs:
+        tables.metadata_schema = tskit.MetadataSchema(root.attrs["metadata_schema"])
+    if "metadata" in root.attrs:
+        tables.metadata = root.attrs["metadata"]
 
     tables.individuals.set_columns(
         flags=root["individuals/flags"],

--- a/tszip/compression.py
+++ b/tszip/compression.py
@@ -283,9 +283,8 @@ def load_zarr(path):
 def decompress_zarr(root):
     tables = tskit.TableCollection(root.attrs["sequence_length"])
     coordinates = root["coordinates"][:]
-    if "metadata_schema" in root.attrs:
+    if "metadata_schema" in root.attrs and "metadata" in root.attrs:
         tables.metadata_schema = tskit.MetadataSchema(root.attrs["metadata_schema"])
-    if "metadata" in root.attrs:
         tables.metadata = root.attrs["metadata"]
 
     tables.individuals.set_columns(


### PR DESCRIPTION
I've been using the top-level metadata to store information related to the coordinates of my tree sequences (since tree sequences only have a sequence_length rather than a start / end position). It appears that this information is lost when compressing / decompressing using tszip. I believe this PR should resolve it; I'm also happy for things to get rewritten in a more sensible way.