### PR TITLE
cli now supports decompressing to stdout

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,7 +4,7 @@
 Command line interface
 ======================
 
-Tszkip is intended to be used primarily as a command line interface.
+Tszip is intended to be used primarily as a command line interface.
 The interface for tszip is modelled directly on
 `gzip <http://linuxcommand.org/lc3_man_pages/gzip1.html>`_, and so
 it should hopefully be immediately familiar and useful to many people.


### PR DESCRIPTION
Inspired by `gzip` where one can decompress to stdout I've added a flag to the cli `-c` that allows one to decompress the tree-sequence to stdout and redirect to a file of their choosing. 
This was inspired by a use-case where I wanted to decompress a single simulation to multiple test cases.  

I'm happy for this edit to be rewritten or a broader discussion of whether this belongs in the CLI. 