### PR TITLE
Require tskit >= 0.3.3 and use flexible file arg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ include_package_data = True
 install_requires =
      numpy
      humanize
-     tskit
+     tskit >=0.3.3
      numcodecs
      zarr
 setup_requires =

--- a/tszip/cli.py
+++ b/tszip/cli.py
@@ -138,7 +138,7 @@ def run_decompress(args):
         check_output(outfile, args)
         with check_load_errors(file_arg):
             ts = tszip.decompress(file_arg)
-        ts.dump(str(outfile))
+        ts.dump(outfile)
         logger.info(f"Wrote {outfile}")
         remove_input(infile, args)
 


### PR DESCRIPTION
Update the code to make things a bit more flexible using newer tskit features.