### PR TITLE
Downgrade h5py, fix pytest.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             # Run setup.py so that the version is defined
             python3 setup.py build
-            pytest --cov=tszip --cov-report=xml --cov-branch -n 8 tests
+            python3 -m pytest --cov=tszip --cov-report=xml --cov-branch -n 2 tests
             codecov
             rm .coverage
 

--- a/requirements/CI-tests-conda.txt
+++ b/requirements/CI-tests-conda.txt
@@ -1,5 +1,5 @@
 humanize==3.4.1
-h5py==3.2.1
+h5py<3.2
 msprime==1.0.0
 pytest==6.2.3
 pytest-cov==2.11.1


### PR DESCRIPTION
Fixes #46 and tszip import errors on CI.