### PR TITLE
Compressing tree-sequences to stdout

### DIFF
--- a/tszip/cli.py
+++ b/tszip/cli.py
@@ -98,16 +98,18 @@ def remove_input(infile, args):
 
 def check_output(outfile, args):
     if outfile.exists():
-        if not args.force:
+        if not (args.force or args.stdout):
             exit(f"'{outfile}' already exists; use --force to overwrite")
+
+
+# Allows us to easily patch when running tests.
+def get_stdout():
+    return sys.stdout.buffer
 
 
 def run_compress(args):
     if args.stdout:
-        exit(
-            "Compressing to stdout not currently supported;"
-            "Please see https://github.com/tskit-dev/tszip/issues/49"
-        )
+        args.keep = True
     setup_logging(args)
     for file_arg in args.files:
         logger.info(f"Compressing {file_arg}")
@@ -119,6 +121,8 @@ def run_compress(args):
         infile = pathlib.Path(file_arg)
         outfile = pathlib.Path(file_arg + args.suffix)
         check_output(outfile, args)
+        if args.stdout:
+            outfile = get_stdout()
         tszip.compress(ts, outfile, variants_only=args.variants_only)
         remove_input(infile, args)
 


### PR DESCRIPTION
In response to #49, I've implemented a version (& some testing) that allows one to compress a single tree to `stdout` and pipe to a file of choice. The code is a bit clunky w.r.t. filehandling so I'm making this as a draft PR initially to get some feedback. 

There is one outstanding thing that I have not added, and that is how to compress multiple tree sequences to the stdout stream and verify that we can read them in sequence (similar to sequential calls to `tskit.load` from a single file).